### PR TITLE
Update unorm_dart dependency to version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.3
 
 - added build management for browser js file
+- update `unorm_dart` to 0.3.0
 
 ### 1.0.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: saslprep
 homepage: https://github.com/konsultaner/saslprep-dart
-version: 1.0.2
+version: 1.0.3
 description: >-
   This package provides the Stringprep (rfc4013) Profile for User Names and Passwords for dart. A port of https://github.com/reklatsmasters/saslprep to the dart lang
 dependencies:
-  pedantic: ^1.11.1
-  unorm_dart: ^0.2.0
+  unorm_dart: ^0.3.0
 dev_dependencies:
   test: ^1.20.1
   build_runner: ^2.1.0
   build_test: ^2.1.0
   build_web_compilers: ^3.0.0
+  pedantic: ^1.11.1
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Simply updates the dependency version.
It has performance improvements, but unfortunately not resolvable by semantic versioning.

The Dart 3 change in the `unorm_dart` changelog is in reality only updating the upper constraints to Dart `<4.0.0`, so this can simply be a patch update, no need to do a `1.1.0` update.
https://github.com/yshrsmz/unorm-dart/commit/2d40c3ae9d5c608bb9f6f00b6d182960ceaae01c